### PR TITLE
Adding new 'replaceParent' method

### DIFF
--- a/jquery.embedly.js
+++ b/jquery.embedly.js
@@ -79,6 +79,7 @@
            if ((_a = settings.method) === 'replace') { return elem.replaceWith(oembed.code); } 
            else if (_a === 'after') { return elem.after(oembed.code); } 
            else if (_a === 'afterParent') { return elem.parent().after(oembed.code); }
+           else if (_a === 'replaceParent') { return elem.parent().replaceWith(oembed.code); }
          }
        }
        var urlValid = function(url){


### PR DESCRIPTION
Useful for when you have a link like `<p><a href="http://so.me/oembed.link">Some Link</a></p>` and want to get rid of the `<p>` and replace it with the default `<div>`
