### PR TITLE
Fixing settings bug (#23)

### DIFF
--- a/jquery.embedly.js
+++ b/jquery.embedly.js
@@ -59,12 +59,8 @@
        var path = "http://api.embed.ly/";
 
        var settings;
-       if (typeof options !== "undefined"){
-         settings = $.extend($.embedly.defaults, options);
-       }
-       else {
-         settings = $.embedly.defaults;
-       }
+       options = options ? options : {};
+       settings = $.extend({}, $.embedly.defaults, options);
        if (!settings.urlRe) {settings.urlRe = window.embedlyURLre; }
        if (typeof urls === "string"){ urls = new Array(urls); }
        if (typeof callback !== "undefined"){ settings.success = callback; }


### PR DESCRIPTION
This patch addresses a major source of headaches: The line

```
settings = $.extend($.embedly.defaults, options);
```

was 1) overwriting `$.embedly.defaults` each time `$.embedly` was called with options, and 2) making `settings` a reference to `$.embedly.defaults`. This was causing `settings.success` to always point to the _last_ `success` callback to be passed to `$.embedly`. So a series of calls like

```
$.embedly(url, {..., success: callback1});
$.embedly(url, {..., success: callback2});
$.embedly(url, {..., success: callback3});
```

would result in three calls to `callback3`!

The correct jQuery-ism is to create a new object, `{}`, and use it as the first argument:

```
settings = $.extend({}, $.embedly.defaults, options);
```

Highly recommend minifying and doing a version bump after merging, as this is a major bug fix.
