### PR TITLE
fixed package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
-  "name": "jquery-plugin",
-  "version": "0.0.0-ignored",
+  "name": "jquery-embedly",
+  "version": "3.1.2",
+  "main": "jquery.embedly.js",
   "engines": {
     "node": ">= 0.6.0"
   },


### PR DESCRIPTION
This solves a lot of problems for people installing embedly via npm.