### PR TITLE
add license info in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,5 +14,6 @@
     "grunt-contrib-concat": "0.1.2rc6",
     "grunt-contrib-uglify": "0.1.1rc6",
     "grunt-contrib-qunit": "~0.1.1"
-  }
+  },
+  "license": "BSD-3-Clause"
 }


### PR DESCRIPTION
I found that package.json lost the license field.