### PR TITLE
Remove redundant version tag from bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,5 @@
 {
   "name": "jquery-embedly",
-  "version": "3.1.2",
   "homepage": "https://embed.ly/",
   "authors": [
     "Art Gibson <art@embed.ly>",


### PR DESCRIPTION
Bower now uses git version tags instead (http://semver.org/).